### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 # Requirements
 
 - iOS 8.0 / Mac OS X 10.9+
-- XCode 6.3+
+- Xcode 6.3+
 - Alamofire 1.2+
 
 # Install *Nap* with Carthage


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
